### PR TITLE
Adding otherTarget to the translated mission files - Part1

### DIFF
--- a/Converters/TranslatedEventActionConverter.cs
+++ b/Converters/TranslatedEventActionConverter.cs
@@ -66,6 +66,9 @@ namespace Imperial_Commander_Editor
 					case 21://D6
 						eventActionAction = item.ToObject<TranslatedCustomEnemyDeployment>();
 						break;
+					case 12://GM2
+						eventActionAction = item.ToObject<TranslatedChangeTarget>();
+						break;
 				}
 				eObserver.Add( eventActionAction );
 			}

--- a/Models/TranslatedMission.cs
+++ b/Models/TranslatedMission.cs
@@ -175,6 +175,9 @@ namespace Imperial_Commander_Editor
 					case EventActionType.D6:
 						eventActions.Add( new TranslatedCustomEnemyDeployment( item ) );
 						break;
+					case EventActionType.GM2:
+						eventActions.Add(new TranslatedChangeTarget(item));
+						break;
 				}
 			}
 		}
@@ -426,6 +429,28 @@ namespace Imperial_Commander_Editor
 			GUID = ea.GUID;
 			eventActionType = ea.eventActionType;
 			repositionText = ((ChangeReposition)ea).theText;
+		}
+	}
+
+	public class TranslatedChangeTarget : ITranslatedEventAction
+	{
+		public Guid GUID { get; set; }
+		public EventActionType eventActionType { get; set; }
+		public string eaName { get; set; }
+
+		public string otherTarget;
+
+		public TranslatedChangeTarget()
+		{
+
+		}
+
+		public TranslatedChangeTarget(IEventAction ea)
+		{
+			eaName = ea.displayName;
+			GUID = ea.GUID;
+			eventActionType = ea.eventActionType;
+			otherTarget = ((ChangeTarget)ea).otherTarget;
 		}
 	}
 


### PR DESCRIPTION
I found a missing translation issue:
"otherTarget" is missing from the translation files (all languages are impacted)

How to repro:
- Start IC2 (and set language to anything else that English)
- Start a single mission (Heart of Empire : Mission 3 for example)
- Once fully loaded, activate Ennemies
=> Look at the Target of the attacks. Instead of a Hero name, there is a 40% change that it's going to display "the closest protester" (**always in English**)

![image](https://github.com/GlowPuff/ICEditor/assets/170425011/994e3578-661a-4a24-8b17-aeddfb75fcc5)

There are 22 Impacted missions :
BESPIN1, BESPIN3, CORE7, CORE12, CORE14, CORE27, EMPIRE3, EMPIRE13, HOTH1, HOTH2, HOTH8, HOTH12, HOTH13, JABBA5, JABBA6, OTHER6, OTHER11, OTHER16, OTHER20, OTHER33, OTHER40, TWIN2

Exact details being :

Missions\Bespin\BESPIN1.json: "otherTarget": "the Rebel carrying the dead drop",
Missions\Bespin\BESPIN3.json: "otherTarget": "the Rebel figure closest to Agent Blaise",
Missions\Core\CORE12.json: "otherTarget": "the hero carrying the data core",
Missions\Core\CORE14.json: "otherTarget": "the closest closed door",
Missions\Core\CORE14.json: "otherTarget": "the closest closed door",
Missions\Core\CORE27.json: "otherTarget": "the Rebel carrying the data core",
Missions\Core\CORE7.json: "otherTarget": "the captive",
Missions\Empire\EMPIRE13.json: "otherTarget": "the closest civilian",
Missions\Empire\EMPIRE3.json: "otherTarget": "the closest protester",
Missions\Hoth\HOTH1.json: "otherTarget": "the closest evacuee",
Missions\Hoth\HOTH12.json: "otherTarget": "Draylen",
Missions\Hoth\HOTH13.json: "otherTarget": "the shuttle door",
Missions\Hoth\HOTH2.json: "otherTarget": "the closest refugee",
Missions\Hoth\HOTH8.json: "otherTarget": "the closest defense checkpoint",
Missions\Hoth\HOTH8.json: "otherTarget": "the siege wall",
Missions\Jabba\JABBA5.json: "otherTarget": "a Rebel figure carrying a spice barrel",
Missions\Jabba\JABBA6.json: "otherTarget": "the closest weak point",
Missions\Other\OTHER11.json: "otherTarget": "the closest refugee",
Missions\Other\OTHER11.json: "otherTarget": "the Force-sensitive refugee",
Missions\Other\OTHER11.json: "otherTarget": "the Force-sensitive refugee",
Missions\Other\OTHER11.json: "otherTarget": "the Force-sensitive refugee",
Missions\Other\OTHER11.json: "otherTarget": "the Force-sensitive refugee",
Missions\Other\OTHER16.json: "otherTarget": "the Rebel carrying the supplies",
Missions\Other\OTHER20.json: "otherTarget": "the hero carrying the access disk",
Missions\Other\OTHER33.json: "otherTarget": "the Rebel carrying the prototype",
Missions\Other\OTHER40.json: "otherTarget": "the marked hero",
Missions\Other\OTHER6.json: "otherTarget": "the closest barricade",
Missions\Twin\TWIN2.json: "otherTarget": "the Rebel carrying the data chip",

------------------
This needs a fix for
 - **part1 : ICEditor :  in order for otherTarget to correctly be exported into the translation files.**
 - part2 : SagaTranslatorModern : to allow translators to translate these otherTargets.
 - part3 : ImperialCommander2 : to correctly display the translated otherTargets.

Current PR is part1

Cheers!
ilu